### PR TITLE
Issue-1: Allow phpunit to Set Up Its Own Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IDEs
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ jobs:
 - Accepts a string.
 - Defaults to `'latest'`.
 
+### `install-wordpress`
+
+- Whether to [install WordPress](https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/install-wp-tests.sh) as part of the pre-test setup. If you are testing a WordPress plugin or theme in isolation, you should set this to 'false' and [install WordPress in your test setup](https://mantle.alley.com/docs/testing#rsyncing-your-project-to-a-wordpress-installation). This should also be set to 'false' if you are using [Mantle CI to install WordPress](https://mantle.alley.com/docs/testing/installation-manager).
+- Accepts a boolean string (`'true'` or `'false'`).
+- Defaults to `'true'`.
+
 ### `wordpress-multisite`
 
 - Specify whether to enable WordPress multisite.

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,18 @@ runs:
         echo "SKIP_INSTALL=$([ "${{ inputs.install-skip }}" = "true" ] || [ "${{ inputs.skip-install }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
         echo "SKIP_AUDIT=$([ "${{ inputs.audit-skip }}" = "true" ] || [ "${{ inputs.skip-audit }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
         echo "SKIP_TEST=$([ "${{ inputs.test-skip }}" = "true" ] || [ "${{ inputs.skip-test }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
+        echo "CACHEDIR=/tmp/test-cache" >> $GITHUB_ENV
+        echo "WP_CORE_DIR=/tmp/wordpress" >> $GITHUB_ENV
+        echo "WP_TESTS_DIR=/tmp/wordpress-tests-lib" >> $GITHUB_ENV
+        echo "WP_VERSION=${{ inputs.wordpress-version }}" >> $GITHUB_ENV
+        echo "WP_DB_HOST=127.0.0.1" >> $GITHUB_ENV
+        echo "WP_DB_USER=root" >> $GITHUB_ENV
+        echo "WP_DB_PASSWORD=" >> $GITHUB_ENV
+        echo "WP_MULTISITE=${{ inputs.wordpress-multisite == true && 1 || 0 }}" >> $GITHUB_ENV
+        echo "PACKAGE_DIRECTORY=${{ format('{0}/wp-content/{1}/', '/tmp/wordpress', inputs.working-directory) }}" >> $GITHUB_ENV
+        echo "WP_TEST_SKIP_DB_CREATE=false" >> $GITHUB_ENV
+        echo "WP_INSTALL_VIP_MU_PLUGINS=${{ inputs.wordpress-host == 'vip' && 'true' || 'false' }}" >> $GITHUB_ENV
+        echo "INSTALL_OBJECT_CACHE=${{ inputs.wordpress-host == 'vip' && 'memcached' || inputs.wordpress-host == 'pantheon' && 'redis' || 'false' }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Generate extension hash per PHP version and extensions
@@ -205,25 +217,11 @@ runs:
     - name: Setup WordPress with core test suite
       if: ${{ inputs.wordpress-version != 'false' && env.SKIP_TEST != 'true' && inputs.install-wordpress == 'true' }}
       shell: bash
-      env:
-        CACHEDIR: /tmp/test-cache # Likely unused
-        WP_CORE_DIR: /tmp/wordpress
-        WP_TESTS_DIR: /tmp/wordpress-tests-lib
-        WP_VERSION: ${{ inputs.wordpress-version }}
-        WP_DB_HOST: 127.0.0.1
-        WP_DB_USER: root
-        WP_DB_PASSWORD: '""'
-        WP_MULTISITE: ${{ inputs.wordpress-multisite == true && 1 || 0 }}
-        PACKAGE_DIRECTORY: ${{ format('{0}/wp-content/{1}/', '/tmp/wordpress', inputs.working-directory) }}
-        WP_TEST_SKIP_DB_CREATE: false
-        WP_INSTALL_VIP_MU_PLUGINS: ${{ inputs.wordpress-host == 'vip' && 'true' || 'false' }}
-        # When hosting provider is VIP, object cache is memcached, when it is Pantheon, object cache is redis,
-        INSTALL_OBJECT_CACHE: ${{ inputs.wordpress-host == 'vip' && 'memcached' || inputs.wordpress-host == 'pantheon' && 'redis' || 'false' }}
       run: |
         bash <(curl -s "https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/install-wp-tests.sh") wordpress_unit_tests ${{ env.WP_DB_USER }} ${{ env.WP_DB_PASSWORD }} ${{ env.WP_DB_HOST }} ${{ env.WP_VERSION }} ${{ env.WP_TEST_SKIP_DB_CREATE }} ${{ env.WP_INSTALL_VIP_MU_PLUGINS }} ${{ env.INSTALL_OBJECT_CACHE }}
-        rsync -aWq --no-compress --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' . ${PACKAGE_DIRECTORY}
+        rsync -aWq --no-compress --exclude '.npm' --exclude '.git' --exclude ${{ env.WP_CORE_DIR }} --exclude 'node_modules' . ${{ env.PACKAGE_DIRECTORY }}
         # Debug for now
-        cd ${PACKAGE_DIRECTORY}
+        cd ${{ env.PACKAGE_DIRECTORY }}
         ls -la
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Install WordPress related services for WP version'
     required: false
     default: 'latest'
+  install-wordpress:
+      description: 'Bootstrap the WordPress Installation'
+      required: false
+      default: 'true'
   wordpress-multisite:
     description: 'Enable WordPress multisite'
     required: false
@@ -199,7 +203,7 @@ runs:
       shell: bash
 
     - name: Setup WordPress with core test suite
-      if: ${{ inputs.wordpress-version != 'false' && env.SKIP_TEST != 'true' }}
+      if: ${{ inputs.wordpress-version != 'false' && env.SKIP_TEST != 'true' && inputs.install-wordpress == 'true' }}
       shell: bash
       env:
         CACHEDIR: /tmp/test-cache # Likely unused
@@ -230,7 +234,7 @@ runs:
 
     # Only run the test-command if it wasn't already run in the WordPress setup
     - name: Run tests
-      if: ${{ env.SKIP_TEST != 'true' && inputs.wordpress-version == 'false' }}
+      if: ${{ env.SKIP_TEST != 'true' && ( inputs.wordpress-version == 'false' || inputs.install-wordpress == 'false' ) }}
       run: ${{ inputs.test-command }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
### Summary

This PR addresses the issue presented in "Allow phpunit to Set Up Its Own Tests". It aims to provide an option to not have GitHub Actions set up the PHP tests, similar to how it's done in the PHP tests workflow, and instead allow phpunit to handle that step during the bootstrap process. This change is intended to enable more flexibility in testing, such as testing plugins in isolation. Fixes #1

### Description

The need for this change arises from the desire to have a more flexible testing setup, particularly when using Mantle CI. The goal is to allow Mantle CI to manage the WordPress setup, file copying, and test execution process without the interference of GitHub Actions in the initial test setup phase.

### Use Case

This change is particularly useful for users who are leveraging Mantle CI for their testing processes. It enables a seamless integration where Mantle CI can take full control of the testing setup, allowing for a more tailored and efficient testing workflow that can accommodate specific needs such as plugin isolation testing.

### Implementation Details

- Modify the GitHub Actions workflow to bypass the PHP test setup phase.
- Ensure compatibility with Mantle CI's bootstrap process for test setup.
- Test the new setup with a sample project to ensure that it works as intended.

### Testing

- Implement unit tests to cover the new functionality.
- Conduct integration testing with Mantile CI to ensure that the workflow operates as expected.
- Review the output of tests to verify that plugin isolation and other specific testing scenarios are adequately supported.

### Documentation

- Update the README and any relevant documentation to reflect the changes in the testing setup process.
- Include examples of how to configure the workflow for users opting to use Mantle CI for their testing needs.

For further details, refer to the original issue: [Allow phpunit to Set Up Its Own Tests](https://github.com/alleyinteractive/action-test-php/issues/1).
