### PR TITLE
Add support for skip-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,15 @@ jobs:
 - Accepts a valid coverage support value (`xdebug`, `pcov`, `none`).
 - Defaults to 'none'.
 
+### `skip-services` or `services-skip`
+
+- Skip starting Docker-based services (mysql, redis, memcached).
+- Accepts a boolean string (`'true'` or `'false'`).
+- Defaults to `'false'`.
+
 ### `wordpress-version`
 
-- Specify the WordPress version to use, or 'false' to skip WordPress installation and related WordPress services. If you specify a version, [test-command](#test-command) will be run from within the context of the WordPress installation.
+- Specify the WordPress version to use, or 'false' to skip WordPress installation. If you specify a version, [test-command](#test-command) will be run from within the context of the WordPress installation's `wp-content` directory.
 - Accepts a string.
 - Defaults to `'latest'`.
 

--- a/action.yml
+++ b/action.yml
@@ -29,11 +29,11 @@ inputs:
     required: false
     default: 'none'
   wordpress-version:
-    description: 'Install WordPress related services for WP version'
+    description: 'Specify the WordPress version to use (false to skip)'
     required: false
     default: 'latest'
   wordpress-multisite:
-    description: 'Enable WordPress multisite'
+    description: 'Enable WordPress multisite (only works with wordpress-version)'
     required: false
     default: 'false'
   wordpress-host:
@@ -92,6 +92,14 @@ inputs:
     description: 'GitHub token for accessing private repositories via composer'
     required: false
     default: ''
+  skip-services:
+    description: 'Skip starting Docker-based services (mysql, redis, memcached)'
+    required: false
+    default: 'false'
+  services-skip:
+    description: 'Skip starting Docker-based services (mysql, redis, memcached)'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -102,6 +110,19 @@ runs:
         echo "SKIP_INSTALL=$([ "${{ inputs.install-skip }}" = "true" ] || [ "${{ inputs.skip-install }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
         echo "SKIP_AUDIT=$([ "${{ inputs.audit-skip }}" = "true" ] || [ "${{ inputs.skip-audit }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
         echo "SKIP_TEST=$([ "${{ inputs.test-skip }}" = "true" ] || [ "${{ inputs.skip-test }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
+        echo "SKIP_SERVICES=$([ "${{ inputs.services-skip }}" = "true" ] || [ "${{ inputs.skip-services }}" = "true" ] && echo "true" || echo "false")" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Environmental variable consistency check
+      run: |
+        # Test for incompatible / unsupported options:
+
+        # If SKIP_SERVICES is true and wordpress-version is not false, fail
+        if [ "${{ env.SKIP_SERVICES }}" = "true" ] && [ "${{ inputs.wordpress-version }}" != "false" ]; then
+          unsupported_configuration=true
+          echo "wordpress-version != false requires SKIP_SERVICES to be false" >&2
+          exit 1
+        fi
       shell: bash
 
     - name: Generate extension hash per PHP version and extensions
@@ -154,8 +175,8 @@ runs:
         restore-keys: |
           ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
 
-    - name: Start WordPress services in the background
-      if: ${{ inputs.wordpress-version != 'false' }}
+    - name: Start services in the background
+      if: ${{ env.SKIP_SERVICES != 'true' }}
       run: |
         docker-compose -f ${{ github.action_path }}/docker-compose.yml up -d
       shell: bash
@@ -172,8 +193,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Wait for WordPress services if needed
-      if: ${{ inputs.wordpress-version != 'false' && env.SKIP_TEST != 'true' }}
+    - name: Wait for services if needed
+      if: ${{ env.SKIP_SERVICES != 'true' }}
       run: |
         echo "Waiting for MySQL, Redis, and Memcached to become healthy..."
         timeout=30  # Timeout after 30 seconds


### PR DESCRIPTION
## Summary

This PR introduces changes to improve the action's versatility for PHP projects that don't require a full WordPress setup but still need associated services.


## Changes

- Added new input: `skip-services`
  - Boolean flag to skip starting Docker-based services (MySQL, Redis, Memcached)
  - Defaults to 'false'
- Modified behavior of wordpress-version:
  - Setting `wordpress-version`: false now skips all WordPress-related setup
  - This change simplifies configuration for non-WordPress projects
- Updated service startup logic:
  - Services now start based on `skip-services` flag instead of `wordpress-version`
  - Ensures services are available for projects using Mantle Testkit or similar frameworks
- Refactored environment variable setup:
  - Moved relevant env var setup outside of WordPress-specific steps
  - Ensures necessary variables are available for custom test setups (e.g., Mantle)


## Rationale

These changes address the needs of modern PHP projects, particularly those using frameworks like Mantle Testkit. These projects often require database and cache services but handle WordPress setup internally. This update allows the action to support a wider range of PHP projects while maintaining backwards compatibility.