### PR TITLE
Fix multisite ENV set

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -156,7 +156,9 @@ runs:
     - name: Get Composer paths
       id: composer-paths
       run: |
-        echo "cache-dir=$(composer config --absolute cache-dir)" >> $GITHUB_ENV
+        COMPOSER_CACHE_DIR=$(composer config --absolute cache-dir)
+        echo "COMPOSER_CACHE_DIR=${COMPOSER_CACHE_DIR}" >> $GITHUB_ENV
+        mkdir -p ${COMPOSER_CACHE_DIR}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
@@ -170,7 +172,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ env.cache-dir }}
+          ${{ env.COMPOSER_CACHE_DIR }}
         key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
         restore-keys: |
           ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}

--- a/action.yml
+++ b/action.yml
@@ -245,14 +245,10 @@ runs:
         # Debug for now
         cd ${PACKAGE_DIRECTORY}
         ls -la
+        echo "WP_MULTISITE=${WP_MULTISITE}"
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then
-          # Output all environment variables to the top of the test command script
-          echo "#!/bin/bash" > action-test-php-test-command.sh
-          echo "# Environment Variables:" >> action-test-php-test-command.sh
-          env >> action-test-php-test-command.sh
-          echo "" >> action-test-php-test-command.sh  # Add a blank line for readability
-          echo "${{ inputs.test-command }}" >> action-test-php-test-command.sh
+          echo "${{ inputs.test-command }}" > action-test-php-test-command.sh
           chmod +x action-test-php-test-command.sh
           bash -ex ./action-test-php-test-command.sh
           rm -f action-test-php-test-command.sh
@@ -262,12 +258,7 @@ runs:
     - name: Run tests
       if: ${{ env.SKIP_TEST != 'true' && inputs.wordpress-version == 'false' }}
       run: |
-          # Output all environment variables to the top of the test command script
-          echo "#!/bin/bash" > action-test-php-test-command.sh
-          echo "# Environment Variables:" >> action-test-php-test-command.sh
-          env >> action-test-php-test-command.sh
-          echo "" >> action-test-php-test-command.sh  # Add a blank line for readability
-          echo "${{ inputs.test-command }}" >> action-test-php-test-command.sh
+          echo "${{ inputs.test-command }}" > action-test-php-test-command.sh
           chmod +x action-test-php-test-command.sh
           bash -ex ./action-test-php-test-command.sh
           rm -f action-test-php-test-command.sh

--- a/action.yml
+++ b/action.yml
@@ -245,7 +245,6 @@ runs:
         # Debug for now
         cd ${PACKAGE_DIRECTORY}
         ls -la
-        echo "WP_MULTISITE=${WP_MULTISITE}"
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then
           echo "${{ inputs.test-command }}" > action-test-php-test-command.sh

--- a/action.yml
+++ b/action.yml
@@ -245,15 +245,30 @@ runs:
         ls -la
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then
-          echo "${{ inputs.test-command }}" > action-test-php-test-command.sh
+          # Output all environment variables to the top of the test command script
+          echo "#!/bin/bash" > action-test-php-test-command.sh
+          echo "# Environment Variables:" >> action-test-php-test-command.sh
+          env >> action-test-php-test-command.sh
+          echo "" >> action-test-php-test-command.sh  # Add a blank line for readability
+          echo "${{ inputs.test-command }}" >> action-test-php-test-command.sh
           chmod +x action-test-php-test-command.sh
           bash -ex ./action-test-php-test-command.sh
+          rm -f action-test-php-test-command.sh
         fi
 
     # Only run the test-command if it wasn't already run in the WordPress setup
     - name: Run tests
       if: ${{ env.SKIP_TEST != 'true' && inputs.wordpress-version == 'false' }}
-      run: ${{ inputs.test-command }}
+      run: |
+          # Output all environment variables to the top of the test command script
+          echo "#!/bin/bash" > action-test-php-test-command.sh
+          echo "# Environment Variables:" >> action-test-php-test-command.sh
+          env >> action-test-php-test-command.sh
+          echo "" >> action-test-php-test-command.sh  # Add a blank line for readability
+          echo "${{ inputs.test-command }}" >> action-test-php-test-command.sh
+          chmod +x action-test-php-test-command.sh
+          bash -ex ./action-test-php-test-command.sh
+          rm -f action-test-php-test-command.sh
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 

--- a/action.yml
+++ b/action.yml
@@ -232,7 +232,7 @@ runs:
         WP_DB_HOST: 127.0.0.1
         WP_DB_USER: root
         WP_DB_PASSWORD: '""'
-        WP_MULTISITE: ${{ inputs.wordpress-multisite == true && 1 || 0 }}
+        WP_MULTISITE: ${{ (inputs.wordpress-multisite == 'true') && '1' || '0' }}
         PACKAGE_DIRECTORY: ${{ format('{0}/wp-content/{1}/', '/tmp/wordpress', inputs.working-directory) }}
         WP_TEST_SKIP_DB_CREATE: false
         WP_INSTALL_CORE_TEST_SUITE: true


### PR DESCRIPTION
## Summary

- Fixes WP_MULTISITE comparison ( string)
- Renames env `COMPOSER_CACHE_DIR` from cache-dir for clarity
- Wraps all test-command in modular script with -ex (debug and fail-on-error)