### PR TITLE
Fix default in README for install-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ jobs:
 
 - Specify the command to run for composer install.
 - Accepts a string.
-- Defaults to `'composer install --no-dev --prefer-dist --no-interaction --no-progress'`.
+- Defaults to `'composer install --prefer-dist --no-interaction --no-progress'`.
 
 ### `audit-skip` or `skip-audit`
 


### PR DESCRIPTION
Updates the README to use the correct default value for `install-command`. By default, dev dependencies will be installed - if you want to use this command and install production-only dependencies, you'll need to provide a custom `install-command` that includes the `--no-dev` flag.

Fixes #8 