### PR TITLE
Feature: ignore docker compose env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -254,13 +254,21 @@ runs:
         EXCLUDE_MU_PLUGINS=""
         if [ "${{ env.WP_INSTALL_VIP_MU_PLUGINS }}" = "true" ]; then
           echo "Excluding mu-plugins from rsync"
-          EXCLUDE_MU_PLUGINS="--exclude 'mu-plugins'"
+          EXCLUDE_MU_PLUGINS="--exclude mu-plugins"
         fi
+        echo "Package directory contents:"
+        ls -la ${PACKAGE_DIRECTORY}
+        echo "Package directory mu-plugins contents:"
+        ls -la ${PACKAGE_DIRECTORY}/mu-plugins/
+        echo "Rsync"
         rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' ${EXCLUDE_MU_PLUGINS} . ${PACKAGE_DIRECTORY}
 
         # Debug for now
         cd ${PACKAGE_DIRECTORY}
         ls -la
+        echo "Post rsync mu-plugins contents:"
+        ls -la ${PACKAGE_DIRECTORY}/mu-plugins/
+
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then
           echo "${{ inputs.test-command }}" > action-test-php-test-command.sh

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,12 @@ runs:
         fi
       shell: bash
 
+    - name: Start services in the background
+      if: ${{ env.SKIP_SERVICES != 'true' }}
+      run: |
+        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
+      shell: bash
+
     - name: Generate extension hash per PHP version and extensions
       id: extension-hash
       run: echo "hash=$(echo '${{ inputs.php-version }}-${{ inputs.php-extensions }}' | md5sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
@@ -184,12 +190,6 @@ runs:
         key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
         restore-keys: |
           ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
-
-    - name: Start services in the background
-      if: ${{ env.SKIP_SERVICES != 'true' }}
-      run: |
-        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
-      shell: bash
 
     - name: Install dependencies
       if: ${{ env.SKIP_INSTALL != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,7 @@ runs:
     - name: Start services in the background
       if: ${{ env.SKIP_SERVICES != 'true' }}
       run: |
-        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
+        docker compose -f ${{ github.action_path }}/docker-compose.yml up -d
       shell: bash
 
     - name: Generate extension hash per PHP version and extensions
@@ -182,12 +182,12 @@ runs:
         composer config -g github-oauth.github.com "${{ inputs.github-token }}"
       shell: bash
 
-    - name: Restore Composer cache
-      id: composer-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ env.COMPOSER_CACHE_DIR }}
-        key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
+    # - name: Restore Composer cache
+    #   id: composer-cache
+    #   uses: actions/cache/restore@v4
+    #   with:
+    #     path: ${{ env.COMPOSER_CACHE_DIR }}
+    #     key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
 
     - name: Install dependencies
       if: ${{ env.SKIP_INSTALL != 'true' }}
@@ -201,11 +201,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Save Composer cache
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ env.COMPOSER_CACHE_DIR }}
-        key: ${{ steps.composer-cache.outputs.cache-primary-key }}
+    # - name: Save Composer cache
+    #   uses: actions/cache/save@v4
+    #   with:
+    #     path: ${{ env.COMPOSER_CACHE_DIR }}
+    #     key: ${{ steps.composer-cache.outputs.cache-primary-key }}
 
     - name: Wait for services if needed
       if: ${{ env.SKIP_SERVICES != 'true' }}
@@ -213,9 +213,9 @@ runs:
         echo "Waiting for MySQL, Redis, and Memcached to become healthy..."
         timeout=30  # Timeout after 30 seconds
         while [ $timeout -gt 0 ]; do
-          mysql_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q mysql | xargs docker inspect -f '{{ .State.Health.Status }}')"
-          redis_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q redis | xargs docker inspect -f '{{ .State.Health.Status }}')"
-          memcached_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q memcached | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          mysql_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q mysql | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          redis_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q redis | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          memcached_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q memcached | xargs docker inspect -f '{{ .State.Health.Status }}')"
 
           if [ "$mysql_health" = "healthy" ] && [ "$redis_health" = "healthy" ] && [ "$memcached_health" = "healthy" ]; then
             echo "All services are healthy."

--- a/action.yml
+++ b/action.yml
@@ -209,9 +209,9 @@ runs:
         echo "Waiting for MySQL, Redis, and Memcached to become healthy..."
         timeout=30  # Timeout after 30 seconds
         while [ $timeout -gt 0 ]; do
-          mysql_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q mysql | xargs docker inspect -f '{{ .State.Health.Status }}')"
-          redis_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q redis | xargs docker inspect -f '{{ .State.Health.Status }}')"
-          memcached_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q memcached | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          mysql_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q mysql | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          redis_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q redis | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          memcached_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q memcached | xargs docker inspect -f '{{ .State.Health.Status }}')"
 
           if [ "$mysql_health" = "healthy" ] && [ "$redis_health" = "healthy" ] && [ "$memcached_health" = "healthy" ]; then
             echo "All services are healthy."

--- a/action.yml
+++ b/action.yml
@@ -188,7 +188,7 @@ runs:
     - name: Start services in the background
       if: ${{ env.SKIP_SERVICES != 'true' }}
       run: |
-        docker compose -f ${{ github.action_path }}/docker-compose.yml up -d
+        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
       shell: bash
 
     - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -249,7 +249,7 @@ runs:
         INSTALL_OBJECT_CACHE: ${{ inputs.wordpress-host == 'vip' && 'memcached' || inputs.wordpress-host == 'pantheon' && 'redis' || 'false' }}
       run: |
         bash <(curl -s "https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/install-wp-tests.sh") wordpress_unit_tests ${{ env.WP_DB_USER }} ${{ env.WP_DB_PASSWORD }} ${{ env.WP_DB_HOST }} ${{ env.WP_VERSION }} ${{ env.WP_TEST_SKIP_DB_CREATE }} ${{ env.WP_INSTALL_VIP_MU_PLUGINS }} ${{ env.INSTALL_OBJECT_CACHE }}
-        rsync -aWq --no-compress --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' . ${PACKAGE_DIRECTORY}
+        rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' . ${PACKAGE_DIRECTORY}
         # Debug for now
         cd ${PACKAGE_DIRECTORY}
         ls -la

--- a/action.yml
+++ b/action.yml
@@ -144,20 +144,20 @@ runs:
       run: echo "hash=$(echo '${{ inputs.php-version }}-${{ inputs.php-extensions }}' | md5sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Setup cache environment
-      id: extcache
-      uses: shivammathur/cache-extensions@v1
-      with:
-        php-version: ${{ inputs.php-version }}
-        extensions: ${{ inputs.php-extensions }}
-        key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
+    # - name: Setup cache environment
+    #   id: extcache
+    #   uses: shivammathur/cache-extensions@v1
+    #   with:
+    #     php-version: ${{ inputs.php-version }}
+    #     extensions: ${{ inputs.php-extensions }}
+    #     key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
 
-    - name: Cache extensions
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.extcache.outputs.dir }}
-        key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
-        restore-keys: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
+    # - name: Cache extensions
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ steps.extcache.outputs.dir }}
+    #     key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
+    #     restore-keys: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/action.yml
+++ b/action.yml
@@ -249,25 +249,15 @@ runs:
         INSTALL_OBJECT_CACHE: ${{ inputs.wordpress-host == 'vip' && 'memcached' || inputs.wordpress-host == 'pantheon' && 'redis' || 'false' }}
       run: |
         bash <(curl -s "https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/install-wp-tests.sh") wordpress_unit_tests ${{ env.WP_DB_USER }} ${{ env.WP_DB_PASSWORD }} ${{ env.WP_DB_HOST }} ${{ env.WP_VERSION }} ${{ env.WP_TEST_SKIP_DB_CREATE }} ${{ env.WP_INSTALL_VIP_MU_PLUGINS }} ${{ env.INSTALL_OBJECT_CACHE }}
-        set -x
+
         # If WP_INSTALL_VIP_MU_PLUGINS is true, we need to exclude mu-plugins from the rsync
         EXCLUDE_MU_PLUGINS=""
         if [ "${{ env.WP_INSTALL_VIP_MU_PLUGINS }}" = "true" ]; then
           echo "Excluding mu-plugins from rsync"
           EXCLUDE_MU_PLUGINS="--exclude mu-plugins"
         fi
-        echo "Package directory contents:"
-        ls -la ${PACKAGE_DIRECTORY}
-        echo "Package directory mu-plugins contents:"
-        ls -la ${PACKAGE_DIRECTORY}/mu-plugins/
-        echo "Rsync"
-        rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' ${EXCLUDE_MU_PLUGINS} . ${PACKAGE_DIRECTORY}
 
-        # Debug for now
-        cd ${PACKAGE_DIRECTORY}
-        ls -la
-        echo "Post rsync mu-plugins contents:"
-        ls -la ${PACKAGE_DIRECTORY}/mu-plugins/
+        rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' ${EXCLUDE_MU_PLUGINS} . ${PACKAGE_DIRECTORY}
 
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then

--- a/action.yml
+++ b/action.yml
@@ -144,20 +144,20 @@ runs:
       run: echo "hash=$(echo '${{ inputs.php-version }}-${{ inputs.php-extensions }}' | md5sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
       shell: bash
 
-    # - name: Setup cache environment
-    #   id: extcache
-    #   uses: shivammathur/cache-extensions@v1
-    #   with:
-    #     php-version: ${{ inputs.php-version }}
-    #     extensions: ${{ inputs.php-extensions }}
-    #     key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
+    - name: Setup cache environment
+      id: extcache
+      uses: shivammathur/cache-extensions@v1
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.php-extensions }}
+        key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
 
-    # - name: Cache extensions
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: ${{ steps.extcache.outputs.dir }}
-    #     key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
-    #     restore-keys: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
+    - name: Cache extensions
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.extcache.outputs.dir }}
+        key: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
+        restore-keys: ${{ runner.os }}-php-${{ steps.extension-hash.outputs.hash }}
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -182,12 +182,12 @@ runs:
         composer config -g github-oauth.github.com "${{ inputs.github-token }}"
       shell: bash
 
-    # - name: Restore Composer cache
-    #   id: composer-cache
-    #   uses: actions/cache/restore@v4
-    #   with:
-    #     path: ${{ env.COMPOSER_CACHE_DIR }}
-    #     key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
+    - name: Restore Composer cache
+      id: composer-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.COMPOSER_CACHE_DIR }}
+        key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
 
     - name: Install dependencies
       if: ${{ env.SKIP_INSTALL != 'true' }}
@@ -201,11 +201,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    # - name: Save Composer cache
-    #   uses: actions/cache/save@v4
-    #   with:
-    #     path: ${{ env.COMPOSER_CACHE_DIR }}
-    #     key: ${{ steps.composer-cache.outputs.cache-primary-key }}
+    - name: Save Composer cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.COMPOSER_CACHE_DIR }}
+        key: ${{ steps.composer-cache.outputs.cache-primary-key }}
 
     - name: Wait for services if needed
       if: ${{ env.SKIP_SERVICES != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -249,8 +249,13 @@ runs:
         INSTALL_OBJECT_CACHE: ${{ inputs.wordpress-host == 'vip' && 'memcached' || inputs.wordpress-host == 'pantheon' && 'redis' || 'false' }}
       run: |
         bash <(curl -s "https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/install-wp-tests.sh") wordpress_unit_tests ${{ env.WP_DB_USER }} ${{ env.WP_DB_PASSWORD }} ${{ env.WP_DB_HOST }} ${{ env.WP_VERSION }} ${{ env.WP_TEST_SKIP_DB_CREATE }} ${{ env.WP_INSTALL_VIP_MU_PLUGINS }} ${{ env.INSTALL_OBJECT_CACHE }}
+        set -x
         # If WP_INSTALL_VIP_MU_PLUGINS is true, we need to exclude mu-plugins from the rsync
-        EXCLUDE_MU_PLUGINS=${{ env.WP_INSTALL_VIP_MU_PLUGINS == 'true' && '--exclude mu-plugins' || '' }}
+        EXCLUDE_MU_PLUGINS=""
+        if [ "${{ env.WP_INSTALL_VIP_MU_PLUGINS }}" = "true" ]; then
+          echo "Excluding mu-plugins from rsync"
+          EXCLUDE_MU_PLUGINS="--exclude 'mu-plugins'"
+        fi
         rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' ${EXCLUDE_MU_PLUGINS} . ${PACKAGE_DIRECTORY}
 
         # Debug for now

--- a/action.yml
+++ b/action.yml
@@ -263,6 +263,9 @@ runs:
 
         rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' ${EXCLUDE_MU_PLUGINS} . ${PACKAGE_DIRECTORY}
 
+        # Change to the package directory
+        cd ${PACKAGE_DIRECTORY}
+
         # If we aren't skipping tests
         if [ "${{ env.SKIP_TEST }}" != 'true' ]; then
           echo "${{ inputs.test-command }}" > action-test-php-test-command.sh

--- a/action.yml
+++ b/action.yml
@@ -133,12 +133,6 @@ runs:
         fi
       shell: bash
 
-    - name: Start services in the background
-      if: ${{ env.SKIP_SERVICES != 'true' }}
-      run: |
-        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
-      shell: bash
-
     - name: Generate extension hash per PHP version and extensions
       id: extension-hash
       run: echo "hash=$(echo '${{ inputs.php-version }}-${{ inputs.php-extensions }}' | md5sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
@@ -188,6 +182,12 @@ runs:
       with:
         path: ${{ env.COMPOSER_CACHE_DIR }}
         key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
+
+    - name: Start services in the background
+      if: ${{ env.SKIP_SERVICES != 'true' }}
+      run: |
+        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
+      shell: bash
 
     - name: Install dependencies
       if: ${{ env.SKIP_INSTALL != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -182,14 +182,12 @@ runs:
         composer config -g github-oauth.github.com "${{ inputs.github-token }}"
       shell: bash
 
-    - name: Cache Composer dependencies
-      uses: actions/cache@v4
+    - name: Restore Composer cache
+      id: composer-cache
+      uses: actions/cache/restore@v4
       with:
-        path: |
-          ${{ env.COMPOSER_CACHE_DIR }}
+        path: ${{ env.COMPOSER_CACHE_DIR }}
         key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
-        restore-keys: |
-          ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles(inputs.cache-dependency-path) }}
 
     - name: Install dependencies
       if: ${{ env.SKIP_INSTALL != 'true' }}
@@ -202,6 +200,12 @@ runs:
       run: ${{ inputs.audit-command }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+
+    - name: Save Composer cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.COMPOSER_CACHE_DIR }}
+        key: ${{ steps.composer-cache.outputs.cache-primary-key }}
 
     - name: Wait for services if needed
       if: ${{ env.SKIP_SERVICES != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -249,7 +249,10 @@ runs:
         INSTALL_OBJECT_CACHE: ${{ inputs.wordpress-host == 'vip' && 'memcached' || inputs.wordpress-host == 'pantheon' && 'redis' || 'false' }}
       run: |
         bash <(curl -s "https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/install-wp-tests.sh") wordpress_unit_tests ${{ env.WP_DB_USER }} ${{ env.WP_DB_PASSWORD }} ${{ env.WP_DB_HOST }} ${{ env.WP_VERSION }} ${{ env.WP_TEST_SKIP_DB_CREATE }} ${{ env.WP_INSTALL_VIP_MU_PLUGINS }} ${{ env.INSTALL_OBJECT_CACHE }}
-        rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' . ${PACKAGE_DIRECTORY}
+        # If WP_INSTALL_VIP_MU_PLUGINS is true, we need to exclude mu-plugins from the rsync
+        EXCLUDE_MU_PLUGINS=${{ env.WP_INSTALL_VIP_MU_PLUGINS == 'true' && '--exclude mu-plugins' || '' }}
+        rsync -aWq --no-compress --delete --exclude '.npm' --exclude '.git' --exclude ${WP_CORE_DIR} --exclude 'node_modules' ${EXCLUDE_MU_PLUGINS} . ${PACKAGE_DIRECTORY}
+
         # Debug for now
         cd ${PACKAGE_DIRECTORY}
         ls -la

--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,7 @@ runs:
     - name: Start services in the background
       if: ${{ env.SKIP_SERVICES != 'true' }}
       run: |
-        docker compose -f ${{ github.action_path }}/docker-compose.yml up -d
+        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
       shell: bash
 
     - name: Generate extension hash per PHP version and extensions
@@ -213,9 +213,9 @@ runs:
         echo "Waiting for MySQL, Redis, and Memcached to become healthy..."
         timeout=30  # Timeout after 30 seconds
         while [ $timeout -gt 0 ]; do
-          mysql_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q mysql | xargs docker inspect -f '{{ .State.Health.Status }}')"
-          redis_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q redis | xargs docker inspect -f '{{ .State.Health.Status }}')"
-          memcached_health="$(docker compose -f ${{ github.action_path }}/docker-compose.yml ps -q memcached | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          mysql_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q mysql | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          redis_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q redis | xargs docker inspect -f '{{ .State.Health.Status }}')"
+          memcached_health="$(docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml ps -q memcached | xargs docker inspect -f '{{ .State.Health.Status }}')"
 
           if [ "$mysql_health" = "healthy" ] && [ "$redis_health" = "healthy" ] && [ "$memcached_health" = "healthy" ]; then
             echo "All services are healthy."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysql", "--user=root", "--execute=SELECT 1"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 2s
       timeout: 3s
-      retries: 10
-      start_period: 10s
+      retries: 5
+      start_period: 5s
 
   redis:
     image: redis:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:lts
+    image: mysql:8
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8
+    image: mysql:lts
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
+      test: ["CMD", "mysql", "--user=root", "--execute=SELECT 1"]
       interval: 2s
       timeout: 3s
-      retries: 5
-      start_period: 5s
+      retries: 10
+      start_period: 10s
 
   redis:
     image: redis:7


### PR DESCRIPTION
If applied this PR will:
- Handle cache/restore and cache/save operations independently
- leverage `--env-file /dev/null` flags in docker compose to prevent reading a .env file in the repository root
- implement logic to --exclude `mu-plugins` from rsync when `WP_INSTALL_VIP_MU_PLUGINS`