### PR TITLE
Revert "Hide Docker pull progress"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
     - name: Start services in the background
       if: ${{ env.SKIP_SERVICES != 'true' }}
       run: |
-        docker compose --quiet-pull --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
+        docker compose --env-file /dev/null -f ${{ github.action_path }}/docker-compose.yml up -d
       shell: bash
 
     - name: Setup cache environment


### PR DESCRIPTION
Reverts alleyinteractive/action-test-php#12 due to `unknown flag: --quiet-pull` error.